### PR TITLE
Feature/cocoapods

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,7 @@
+Copyright 2020 3 Sided Cube.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/MessageStackView.podspec
+++ b/MessageStackView.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name = 'MessageStackView'
+  s.version = '1.0.0'
+  s.license = 'MIT'
+  s.summary = 'Simple wrapper of UIStackView for posting and removing messages'
+  s.homepage = 'https://github.com/3sidedcube/MessageStackView'
+  s.authors = { '3 Sided Cube' => 'https://3sidedcube.com' }
+  s.source = { :git => 'https://github.com/3sidedcube/MessageStackView.git', :tag => s.version }
+  s.documentation_url = s.homepage
+
+  s.ios.deployment_target = '10.0'
+  s.swift_versions = ['5.0', '5.1']
+  s.source_files = 'Sources/**/*.swift'
+end

--- a/MessageStackView.podspec
+++ b/MessageStackView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'MessageStackView'
-  s.version = 'v2.0.0-rc1'
+  s.version = '2.0.0'
   s.license = 'MIT'
   s.summary = 'Simple wrapper of UIStackView for posting and removing messages'
   s.homepage = 'https://github.com/3sidedcube/MessageStackView'
@@ -11,4 +11,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.swift_versions = ['5.0', '5.1']
   s.source_files = 'Sources/**/*.swift'
+  s.ios.framework  = 'UIKit'
 end

--- a/MessageStackView.podspec
+++ b/MessageStackView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'MessageStackView'
-  s.version = '1.0.0'
+  s.version = 'v2.0.0-rc1'
   s.license = 'MIT'
   s.summary = 'Simple wrapper of UIStackView for posting and removing messages'
   s.homepage = 'https://github.com/3sidedcube/MessageStackView'


### PR DESCRIPTION
Add support for Cocoapods.

**Note**
It seemed the `.podspec` file required a tag of the form X.X.X so had to tag `2.0.0`. 
But I may plan on deleting and retagging when we are happy with the release version.
At this point we merge a `release/2.0.0` branch into `master` and tag.