### PR TITLE
Moves `ShadowComponents` out of `UIView` so it doesn't clash with other libraries

### DIFF
--- a/Sources/Extensions/UIView+Shadow.swift
+++ b/Sources/Extensions/UIView+Shadow.swift
@@ -20,7 +20,7 @@ extension UIView {
             clipsToBounds = false
         }
         
-        shadow = ShadowComponents(
+        shadowComponents = ShadowComponents(
             radius: 1,
             opacity: 0.6,
             color: .lightGray,
@@ -35,7 +35,7 @@ extension UIView {
             layer.masksToBounds = false
             clipsToBounds = false
         }
-        shadow = nil
+        shadowComponents = nil
     }
 }
 

--- a/Sources/Extensions/UIView+ShadowComponents.swift
+++ b/Sources/Extensions/UIView+ShadowComponents.swift
@@ -51,7 +51,7 @@ public struct ShadowComponents {
 
 public extension UIView {
     
-    var shadow: ShadowComponents? {
+    var shadowComponents: ShadowComponents? {
         set {
             guard let newValue = newValue else {
                 layer.shadowColor = UIColor.black.cgColor

--- a/Sources/Extensions/UIView+ShadowComponents.swift
+++ b/Sources/Extensions/UIView+ShadowComponents.swift
@@ -8,48 +8,48 @@
 
 import UIKit
 
-public extension UIView {
+/// Component representation of all properties required to render a shadow in UIKit
+public struct ShadowComponents {
     
-    /// Component representation of all properties required to render a shadow in UIKit
-    struct ShadowComponents {
-        
-        /// The blur radius of the shadow
-        let radius: CGFloat
-        
-        /// The opacity of the shadow
-        let opacity: Float
-        
-        /// The color of the shadow
-        let color: UIColor
-        
-        /// The offset of the shadow
-        let offset: CGSize
-        
-        /// Default public memberwise initialiser
-        /// - Parameters:
-        ///   - radius: The blur radius of the shadow
-        ///   - opacity: The opacity of the shadow
-        ///   - color: The color of the shadow
-        ///   - offset: The offset of the shadow
-        public init(
-            radius: CGFloat,
-            opacity: Float,
-            color: UIColor,
-            offset: CGSize
-        ) {
-            self.radius = radius
-            self.opacity = opacity
-            self.color = color
-            self.offset = offset
-        }
-        
-        static let `default` = ShadowComponents(
-            radius: 3,
-            opacity: 0.6,
-            color: .lightGray,
-            offset: .zero
-        )
+    /// The blur radius of the shadow
+    public let radius: CGFloat
+    
+    /// The opacity of the shadow
+    public let opacity: Float
+    
+    /// The color of the shadow
+    public let color: UIColor
+    
+    /// The offset of the shadow
+    public let offset: CGSize
+    
+    /// Default public memberwise initialiser
+    /// - Parameters:
+    ///   - radius: The blur radius of the shadow
+    ///   - opacity: The opacity of the shadow
+    ///   - color: The color of the shadow
+    ///   - offset: The offset of the shadow
+    public init(
+        radius: CGFloat,
+        opacity: Float,
+        color: UIColor,
+        offset: CGSize
+    ) {
+        self.radius = radius
+        self.opacity = opacity
+        self.color = color
+        self.offset = offset
     }
+    
+    public static let `default` = ShadowComponents(
+        radius: 3,
+        opacity: 0.6,
+        color: .lightGray,
+        offset: .zero
+    )
+}
+
+public extension UIView {
     
     var shadow: ShadowComponents? {
         set {

--- a/Sources/Messages/BadgeMessage/BadgeMessageView.swift
+++ b/Sources/Messages/BadgeMessage/BadgeMessageView.swift
@@ -41,7 +41,7 @@ open class BadgeMessageView: UIView {
     }
     
     /// Overrideable default shadow components for `BadgeMessageView`
-    public static var shadowComponents: UIView.ShadowComponents = .default
+    public static var shadowComponents: ShadowComponents = .default
     
     // MARK: - Subviews
     

--- a/Sources/Messages/BadgeMessage/BadgeMessageView.swift
+++ b/Sources/Messages/BadgeMessage/BadgeMessageView.swift
@@ -136,7 +136,7 @@ open class BadgeMessageView: UIView {
         // cornerRadius
         layer.cornerRadius = Constants.cornerRadius
         containerView.layer.cornerRadius = layer.cornerRadius
-        shadow = BadgeMessageView.shadowComponents
+        shadowComponents = BadgeMessageView.shadowComponents
         
         if #available(iOS 13.0, *) {
             layer.cornerCurve = .continuous

--- a/Sources/Views/Badges/BadgeContainerView.swift
+++ b/Sources/Views/Badges/BadgeContainerView.swift
@@ -87,7 +87,7 @@ open class BadgeContainerView: UIView {
     
     private func setup() {
         backgroundColor = .clear
-        shadow = BadgeContainerView.shadowComponents
+        shadowComponents = BadgeContainerView.shadowComponents
         updateLayer()
     }
     

--- a/Sources/Views/Badges/BadgeContainerView.swift
+++ b/Sources/Views/Badges/BadgeContainerView.swift
@@ -15,7 +15,7 @@ import UIKit
 open class BadgeContainerView: UIView {
     
     /// Overrideable default shadow components for `BadgeContainerView`
-    public static var shadowComponents: UIView.ShadowComponents = .default
+    public static var shadowComponents: ShadowComponents = .default
     
     /// Fixed constants
     private struct Constants {


### PR DESCRIPTION
`UIView.ShadowComponents` was clashing with the same struct in an extension on `UIView` in other libraries, this removes the clash!