### PR TITLE
Adds imageSizeRatio property to `BadgeView`

### DIFF
--- a/Sources/Views/Badges/BadgeView.swift
+++ b/Sources/Views/Badges/BadgeView.swift
@@ -11,13 +11,6 @@ import UIKit
 /// `UIView` for displaying a badge.
 open class BadgeView: BadgeContainerView {
     
-    /// Fixed constants for `BadgeView`
-    private struct Constants {
-        
-        /// Width of `imageView` subview relative to `self`
-        static let imageViewWidthScale: CGFloat = 0.65
-    }
-    
     /// `UIImageView` subview
     public private(set) lazy var imageView: UIImageView = {
         let imageView = UIImageView()
@@ -26,8 +19,24 @@ open class BadgeView: BadgeContainerView {
         imageView.contentMode = .scaleAspectFit
         return imageView
     }()
+
+    /// The constraint between the image view's width and the
+    /// container view's width. Can be adjusted to change how much
+    /// of the container the image fills
+    private var imageWidthConstraint: NSLayoutConstraint?
     
     // MARK: - Computed
+
+    /// Width of `imageView` subview relative to `self`
+    public var imageSizeRatio: CGFloat = 0.65 {
+        didSet {
+            if let widthConstraint = imageWidthConstraint {
+                imageView.removeConstraint(widthConstraint)
+            }
+            setupImageWidthConstraint()
+            setNeedsUpdateConstraints()
+        }
+    }
 
     /// Allows setting the rendering mode of the image view,
     /// defaults to `.alwaysTemplate`
@@ -79,14 +88,19 @@ open class BadgeView: BadgeContainerView {
     private func setup() {
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        setupImageWidthConstraint()
         NSLayoutConstraint.activate([
             imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            imageView.widthAnchor.constraint(
-                equalTo: widthAnchor, multiplier:
-                Constants.imageViewWidthScale
-            ),
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor)
         ])
+    }
+
+    private func setupImageWidthConstraint() {
+        imageWidthConstraint = imageView.widthAnchor.constraint(
+            equalTo: widthAnchor,
+            multiplier: imageSizeRatio
+        )
+        imageWidthConstraint?.isActive = true
     }
 }

--- a/Sources/Views/Badges/BadgeView.swift
+++ b/Sources/Views/Badges/BadgeView.swift
@@ -23,17 +23,14 @@ open class BadgeView: BadgeContainerView {
     /// The constraint between the image view's width and the
     /// container view's width. Can be adjusted to change how much
     /// of the container the image fills
-    private var imageWidthConstraint: NSLayoutConstraint?
+    private var imageWidthConstraint: NSLayoutConstraint!
     
     // MARK: - Computed
 
     /// Width of `imageView` subview relative to `self`
     public var imageSizeRatio: CGFloat = 0.65 {
         didSet {
-            if let widthConstraint = imageWidthConstraint {
-                imageView.removeConstraint(widthConstraint)
-            }
-            setupImageWidthConstraint()
+            updateImageWidthConstraint()
             setNeedsUpdateConstraints()
         }
     }
@@ -88,7 +85,7 @@ open class BadgeView: BadgeContainerView {
     private func setup() {
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        setupImageWidthConstraint()
+        updateImageWidthConstraint()
         NSLayoutConstraint.activate([
             imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -96,7 +93,10 @@ open class BadgeView: BadgeContainerView {
         ])
     }
 
-    private func setupImageWidthConstraint() {
+    private func updateImageWidthConstraint() {
+        if let widthConstraint = imageWidthConstraint {
+            imageView.removeConstraint(widthConstraint)
+        }
         imageWidthConstraint = imageView.widthAnchor.constraint(
             equalTo: widthAnchor,
             multiplier: imageSizeRatio


### PR DESCRIPTION
Adds image size ratio so that we can define externally how much of the `BadgeView` the internal icon consumes. This is used to create app scroller in ARC First Aid. Has been tested locally in that project, won't provide screenshots as it's pre-release and not sure if ARC will want in the wild!