### PR TITLE
🟠 Normal: Switch off asset symbols generation [XS]

### DIFF
--- a/MessageStackView.xcodeproj/project.pbxproj
+++ b/MessageStackView.xcodeproj/project.pbxproj
@@ -1307,6 +1307,7 @@
 		OBJ_88 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1345,6 +1346,7 @@
 		OBJ_89 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Automatically generating asset symbols was causing issues when Carthage was compiling this framework.