### PR TITLE
fix(security): SEC-619 raise minimum deployment target to iOS 17

### DIFF
--- a/MessageStackView.podspec
+++ b/MessageStackView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'MessageStackView'
-  s.version = '3.0.0'
+  s.version = '4.2.1'
   s.license = 'MIT'
   s.summary = 'Simple wrapper of UIStackView for posting and removing messages'
   s.homepage = 'https://github.com/3sidedcube/MessageStackView'
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/3sidedcube/MessageStackView.git', :tag => s.version }
   s.documentation_url = s.homepage
 
-  s.ios.deployment_target = '14.0'
+  s.ios.deployment_target = '17.0'
   s.swift_versions = ['5.7']
   s.source_files = 'Sources/**/*.{swift,h,m}'
   s.ios.framework  = 'UIKit'

--- a/MessageStackView.xcodeproj/project.pbxproj
+++ b/MessageStackView.xcodeproj/project.pbxproj
@@ -1030,7 +1030,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1094,7 +1094,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Example/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1117,7 +1117,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.2.0";
 				SDKROOT = iphoneos;
@@ -1131,7 +1131,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD = /usr/bin/true;
 				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.2.0";
 				SDKROOT = iphoneos;
@@ -1339,13 +1339,13 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.2.0;
+				MARKETING_VERSION = 4.2.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_CFLAGS = "$(inherited)";
@@ -1382,13 +1382,13 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
-				MARKETING_VERSION = 4.2.0;
+				MARKETING_VERSION = 4.2.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++14";
 				OTHER_CFLAGS = "$(inherited)";

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "MessageStackView",
     platforms: [
-        .iOS(.v16)
+        .iOS(.v17)
     ],
     products: [
         .library(


### PR DESCRIPTION
## Why

Pen test (SEC-619) flags EOL minimum OS versions in embedded frameworks of the Blood iOS app. This is one of 8 3SC frameworks being raised to a minimum deployment target of iOS 17.0.

## What changed

- `IPHONEOS_DEPLOYMENT_TARGET`: 16.0 → 17.0 (all 6 occurrences in `project.pbxproj`; macOS settings untouched)
- `Package.swift`: `.iOS(.v16)` → `.iOS(.v17)`
- `MessageStackView.podspec`: `s.ios.deployment_target` 14.0 → 17.0, `s.version` 3.0.0 → 4.2.1 (was stale)
- `MARKETING_VERSION`: 4.2.0 → 4.2.1

## Build & test results

- `xcodebuild build` (scheme `MessageStackView`, generic/platform=iOS): **BUILD SUCCEEDED**
- `xcodebuild test` (scheme `MessageStackViewTests`, iPhone 17 simulator): **TEST SUCCEEDED** — 6 tests, 0 failures

## New warnings introduced by the bump

None. Existing deprecation warnings (`UIApplication.windows` and `UIButton.contentEdgeInsets`, both deprecated in iOS 15) were already emitted at the previous 16.0 target and are unchanged. Remaining warnings are pre-existing SwiftLint findings.

## Note for consumers

Consumer apps must target **iOS >= 17.0** to adopt this version.